### PR TITLE
upgrade to mavericks

### DIFF
--- a/defaults.gypi
+++ b/defaults.gypi
@@ -4,7 +4,7 @@
   ]
 , "target_defaults":
   { "variables":
-    { "MACOSX_VERSION": "10.8"
+    { "MACOSX_VERSION": "10.9"
     }
   , "default_configuration": "opt"
   , "configurations":


### PR DESCRIPTION
Hi there! I loved Ares growing up and I would love to be a contributor to Antares.

I had to change a variable to allow builds on Mavericks - which I know isn't great if you yourself haven't updated. I don't know much about gyp, but maybe there's a way to accept the OSX version from the system environment instead of a variable in this build config?