### PR TITLE
Sync antares_launcher and ls-scenarios (stderr)

### DIFF
--- a/scripts/antares_launcher.py
+++ b/scripts/antares_launcher.py
@@ -136,7 +136,7 @@ def ls_scenarios():
     if FACTORY_SCENARIO:
         args += ["--factory-scenario", FACTORY_SCENARIO]
     print(" ".join(args))
-    out = subprocess.check_output(args)
+    out = subprocess.check_output(args, stderr=subprocess.STDOUT)
     scenarios = []
     for line in out.splitlines():
         if not line[0].isspace():


### PR DESCRIPTION
In commit 038c57a135629b9d136d9265943b51ef9ec585f7 ls-scenarios.cpp was modified to output to stderr instead of stdout, but antares_launcher.py expects to read scenarios from stdout. Redirecting stderr to stdout when calling ls-scenarios.cpp from antares_launcher.py fixes this. I don't think a single argument would be considered a copyrightable contribution so I haven't modified AUTHORS, but I can do so if needed.