### PR TITLE
Makefile: Install the text directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ install-data: build
 	cp -r data/sounds $(DESTDIR)$(DATADIR)/app
 	cp -r data/sprites $(DESTDIR)$(DATADIR)/app
 	cp -r data/strings $(DESTDIR)$(DATADIR)/app
+	cp -r data/text $(DESTDIR)$(DATADIR)/app
 
 .PHONY: install-scenario
 install-scenario: build


### PR DESCRIPTION
This fixes a crash at the end of the tutorial level when antares is installed on the system.
```
antares-glfw: text/6000.txt: couldn't find resource "text/6000.txt"
```
Note I only tested this against `0.9.0`.