### PR TITLE
Fix the build with clang-3.8.0.

### DIFF
--- a/src/drawing/styled-text.cpp
+++ b/src/drawing/styled-text.cpp
@@ -19,6 +19,7 @@
 #include "drawing/styled-text.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <limits>
 #include <pn/output>
 


### PR DESCRIPTION
This fixes the build with `clang-3.8.0` in Slackare-14.2.

See https://github.com/arescentral/antares/issues/308#issuecomment-572625262

Fixes https://github.com/arescentral/antares/issues/308