### PR TITLE
Clean up sound channels before destroying the sound driver.

### DIFF
--- a/include/game/sys.hpp
+++ b/include/game/sys.hpp
@@ -76,6 +76,7 @@ struct SystemGlobals {
 extern SystemGlobals sys;
 
 void sys_init();
+void sys_shutdown();
 
 }  // namespace antares
 

--- a/include/sound/fx.hpp
+++ b/include/sound/fx.hpp
@@ -37,6 +37,7 @@ class SoundFX {
     ~SoundFX();
 
     void init();
+    void shutdown();
     void load(pn::string_view id);
     void reset();
     void stop();

--- a/include/sound/music.hpp
+++ b/include/sound/music.hpp
@@ -42,6 +42,7 @@ class Music {
     };
 
     void init();
+    void shutdown();
     void play(Type type, pn::string_view song);
     void stop();
     void toggle();

--- a/include/ui/flows/master.hpp
+++ b/include/ui/flows/master.hpp
@@ -30,6 +30,7 @@ namespace antares {
 class Master : public Card {
   public:
     Master(sfz::optional<pn::string_view> plugin_path, int32_t seed);
+    ~Master();
 
     virtual void become_front();
     virtual void draw() const;
@@ -52,6 +53,7 @@ class Master : public Card {
     bool                      _skipped;
     Texture                   _publisher_screen;
     Texture                   _ego_screen;
+    bool                      _initialized;
 };
 
 }  // namespace antares

--- a/src/game/sys.cpp
+++ b/src/game/sys.cpp
@@ -70,4 +70,11 @@ void sys_init() {
     sys.right_instrument_texture = Resource::texture(kInstRightPictID);
 }
 
+void sys_shutdown() {
+    if (sys.audio) {
+        sys.music.shutdown();
+        sys.sound.shutdown();
+    }
+}
+
 }  // namespace antares

--- a/src/sound/fx.cpp
+++ b/src/sound/fx.cpp
@@ -200,6 +200,11 @@ void SoundFX::init() {
     reset();
 }
 
+void SoundFX::shutdown() {
+    sounds.resize(0);
+    channels.resize(0);
+}
+
 void SoundFX::reset() {
     sounds.resize(kMinVolatileSound);
     for (int i = 0; i < kMinVolatileSound; ++i) {

--- a/src/sound/music.cpp
+++ b/src/sound/music.cpp
@@ -42,6 +42,11 @@ void Music::init() {
     _channel = sys.audio->open_channel();
 }
 
+void Music::shutdown() {
+    _song_sound.reset();
+    _channel.reset();
+}
+
 void Music::play(Type type, pn::string_view song) {
     bool   play   = false;
     double volume = 1.0;

--- a/src/ui/flows/master.cpp
+++ b/src/ui/flows/master.cpp
@@ -68,7 +68,15 @@ Master::Master(sfz::optional<pn::string_view> plugin_path, int32_t seed)
                   plugin_path.has_value() ? sfz::make_optional(plugin_path->copy())
                                           : sfz::nullopt),
           _seed(seed),
-          _skipped(false) {}
+          _skipped(false),
+          _initialized(false) {}
+
+
+Master::~Master() {
+    if (_initialized) {
+        sys_shutdown();
+    }
+}
 
 void Master::become_front() {
     switch (_state) {
@@ -118,6 +126,8 @@ void Master::become_front() {
 void Master::draw() const {}
 
 void Master::init() {
+    _initialized = true;
+
     RgbColor initialFadeColor;
 
     init_globals();


### PR DESCRIPTION
Attempting to clean up audio resources before destroying the driver to make writing the XAudio2 driver easier.

(Basically if we don't do this then the XAudio2 driver has to track all of its active resources and orphan them so they can be deleted safely in the global destructor, which is annoying.)