### PR TITLE
Fix sound resampling not working in XAudio2 driver

### DIFF
--- a/src/sound/xaudio2-driver.cpp
+++ b/src/sound/xaudio2-driver.cpp
@@ -337,8 +337,7 @@ class XAudio2SoundDriver::XAudio2Channel : public SoundChannel {
         IXAudio2SourceVoice* source_voice;
         check_hresult(
                 "CreateSourceVoice", _driver.get_xa2()->CreateSourceVoice(
-                        &source_voice, &format, XAUDIO2_VOICE_NOSRC,
-                                             XAUDIO2_MAX_FREQ_RATIO, _driver.get_voice_callbacks()));
+                        &source_voice, &format, 0, XAUDIO2_MAX_FREQ_RATIO, _driver.get_voice_callbacks()));
 
         try {
             _source_voice.reset(new XAudio2SourceVoiceInstance(_driver, source_voice));


### PR DESCRIPTION
Per documentation, "The XAUDIO2_VOICE_NOSRC flag causes the voice to behave as though the XAUDIO2_VOICE_NOPITCH flag also is specified."

This is bad because it means pitch scaling, which is used to compensate for sounds not matching the output rate, is not working.

Improves #407 somewhat.