### PR TITLE
Increase stereo separation to full

### DIFF
--- a/src/data/audio.cpp
+++ b/src/data/audio.cpp
@@ -152,7 +152,7 @@ SoundData convert(pn::data_view in) {
     settings.mChannels         = 2;
     settings.mBits             = 16;
     settings.mFrequency        = 44100;
-    settings.mStereoSeparation = 128;
+    settings.mStereoSeparation = 256;
     settings.mResamplingMode   = MODPLUG_RESAMPLE_NEAREST;  // "Low" quality, but matches original game's behavior and makes most instruments sound sharper
     ModPlug_SetSettings(&settings);
     std::unique_ptr<::ModPlugFile, decltype(&ModPlug_Unload)> file(


### PR DESCRIPTION
Mentioned in #400 that it seemed like stereo panning wasn't working right, and assumed it was a conversion issue.  It's actually a rendering issue, ModPlug is configured to render songs with half of their normal stereo separation.  This increases it to full.