### PR TITLE
replace GL_RGBA with GL_RGBA8: fixes image colors and illegible text fg/bg contrast

### DIFF
--- a/src/video/opengl-driver.cpp
+++ b/src/video/opengl-driver.cpp
@@ -224,7 +224,7 @@ class OpenGlTextureImpl : public Texture::Impl {
         copy.fill(RgbColor::clear());
         copy.view(Rect(1, 1, size.width - 1, size.height - 1)).copy(image);
         glTexImage2D(
-                GL_TEXTURE_RECTANGLE, 0, GL_RGBA, size.width, size.height, 0, GL_BGRA, type,
+                GL_TEXTURE_RECTANGLE, 0, GL_RGBA8, size.width, size.height, 0, GL_BGRA, type,
                 copy.bytes());
     }
 


### PR DESCRIPTION
Colors were wrong throughout the game for me. The initial text scroll showed blocks of red instead of words, and some buttons could not be read because there wasn't enough contrast between the background and the text. Everything had a greenish tint, and did not look like the original Ares.

My system:
MacBook M1 Pro
Linux 6.5.0-asahi-15-1-edge-ARCH aarch64

# Before
<img width="313" alt="ares_bgr" src="https://github.com/arescentral/antares/assets/7785285/420bf9e4-df03-4835-8285-8b71ddb70ed7">


# After
<img width="313" alt="ares_rgb" src="https://github.com/arescentral/antares/assets/7785285/73388d20-ecfa-4c63-8d70-261693a4d19f">
