### PR TITLE
Instant fullscreen via video options screen

### DIFF
--- a/include/glfw/video-driver.hpp
+++ b/include/glfw/video-driver.hpp
@@ -42,6 +42,7 @@ class GLFWVideoDriver : public OpenGlVideoDriver {
 
     virtual Size viewport_size() const { return _viewport_size; }
     virtual Size screen_size() const { return _screen_size; }
+    virtual void set_fullscreen(const bool on);
 
     virtual Point     get_mouse();
     virtual InputMode input_mode() const;

--- a/include/mac/c/CocoaVideoDriver.h
+++ b/include/mac/c/CocoaVideoDriver.h
@@ -44,6 +44,7 @@ int32_t antares_window_screen_width(const AntaresWindow* window);
 int32_t antares_window_screen_height(const AntaresWindow* window);
 int32_t antares_window_viewport_width(const AntaresWindow* window);
 int32_t antares_window_viewport_height(const AntaresWindow* window);
+void    antares_window_toggle_fullscreen(AntaresWindow* window);
 
 void antares_get_mouse_location(AntaresWindow* window, int32_t* x, int32_t* y);
 

--- a/include/mac/video-driver.hpp
+++ b/include/mac/video-driver.hpp
@@ -40,6 +40,7 @@ class CocoaVideoDriver : public OpenGlVideoDriver {
 
     virtual Size viewport_size() const;
     virtual Size screen_size() const;
+    virtual void set_fullscreen(const bool on);
 
     virtual Point     get_mouse();
     virtual InputMode input_mode() const;

--- a/include/video/driver.hpp
+++ b/include/video/driver.hpp
@@ -43,10 +43,11 @@ class VideoDriver {
     VideoDriver& operator=(const VideoDriver&) = delete;
 
     virtual ~VideoDriver();
-    virtual Point     get_mouse()         = 0;
-    virtual InputMode input_mode() const  = 0;
-    virtual int       scale() const       = 0;
-    virtual Size      screen_size() const = 0;
+    virtual Point     get_mouse()                   = 0;
+    virtual InputMode input_mode() const            = 0;
+    virtual int       scale() const                 = 0;
+    virtual Size      screen_size() const           = 0;
+    virtual void      set_fullscreen(const bool on) = 0;
 
     virtual bool start_editing(TextReceiver* text) = 0;
     virtual void stop_editing(TextReceiver* text)  = 0;

--- a/include/video/offscreen-driver.hpp
+++ b/include/video/offscreen-driver.hpp
@@ -43,6 +43,7 @@ class OffscreenVideoDriver : public OpenGlVideoDriver {
         return {_screen_size.width * _scale, _screen_size.height * _scale};
     }
     virtual Size screen_size() const { return _screen_size; }
+    virtual void set_fullscreen(const bool on) {};
 
     virtual Point     get_mouse() { return _scheduler->get_mouse(); }
     virtual InputMode input_mode() const { return _scheduler->input_mode(); }

--- a/include/video/text-driver.hpp
+++ b/include/video/text-driver.hpp
@@ -36,6 +36,7 @@ class TextVideoDriver : public VideoDriver {
     virtual InputMode input_mode() const { return KEYBOARD_MOUSE; }
     virtual int       scale() const;
     virtual Size      screen_size() const { return _size; }
+    virtual void      set_fullscreen(const bool on);
 
     virtual bool start_editing(TextReceiver* text);
     virtual void stop_editing(TextReceiver* text);

--- a/src/glfw/video-driver.cpp
+++ b/src/glfw/video-driver.cpp
@@ -182,6 +182,10 @@ GLFWVideoDriver::~GLFWVideoDriver() { glfwTerminate(); }
 
 pn::string_view GLFWVideoDriver::glsl_version() const { return _glsl_version; }
 
+void GLFWVideoDriver::set_fullscreen(const bool on) {
+  window_maximize(on);
+}
+
 Point GLFWVideoDriver::get_mouse() {
     double x, y;
     glfwGetCursorPos(_window, &x, &y);

--- a/src/mac/c/CocoaVideoDriver.m
+++ b/src/mac/c/CocoaVideoDriver.m
@@ -127,7 +127,7 @@ AntaresWindow* antares_window_create(
     [window.window makeKeyAndOrderFront:NSApp];
     [window.window makeFirstResponder:window.view];
     if (fullscreen) {
-        [window.window toggleFullScreen:nil];
+        /* [window.window toggleFullScreen:nil]; */
     } else {
         [window.window center];
     }
@@ -168,6 +168,10 @@ static bool translate_coords(AntaresView* view, NSEvent* event, NSPoint* p) {
     NSSize view_size = [view bounds].size;
     *p               = NSMakePoint(input.x, view_size.height - input.y);
     return true;
+}
+
+void antares_window_toggle_fullscreen(AntaresWindow* window) {
+    [window->window toggleFullScreen:nil];
 }
 
 void antares_get_mouse_location(AntaresWindow* window, int32_t* x, int32_t* y) {

--- a/src/mac/c/CocoaVideoDriver.m
+++ b/src/mac/c/CocoaVideoDriver.m
@@ -126,10 +126,9 @@ AntaresWindow* antares_window_create(
     [window.window setContentView:window.view];
     [window.window makeKeyAndOrderFront:NSApp];
     [window.window makeFirstResponder:window.view];
+    [window.window center];
     if (fullscreen) {
-        /* [window.window toggleFullScreen:nil]; */
-    } else {
-        [window.window center];
+        [window.window toggleFullScreen:nil];
     }
     window.window.delegate = window.view;
     return memdup(&window, sizeof(AntaresWindow));

--- a/src/mac/video-driver.cpp
+++ b/src/mac/video-driver.cpp
@@ -110,6 +110,7 @@ Size CocoaVideoDriver::screen_size() const {
 void CocoaVideoDriver::set_fullscreen(const bool on) {
     if (sys.prefs->fullscreen() != on) {
         antares_window_toggle_fullscreen(_window);
+        sys.prefs->set_fullscreen(on);
     }
 }
 

--- a/src/mac/video-driver.cpp
+++ b/src/mac/video-driver.cpp
@@ -107,6 +107,12 @@ Size CocoaVideoDriver::screen_size() const {
     };
 }
 
+void CocoaVideoDriver::set_fullscreen(const bool on) {
+    if (sys.prefs->fullscreen() != on) {
+        antares_window_toggle_fullscreen(_window);
+    }
+}
+
 Point CocoaVideoDriver::get_mouse() {
     Point p;
     antares_get_mouse_location(_window, &p.h, &p.v);

--- a/src/ui/screens/options.cpp
+++ b/src/ui/screens/options.cpp
@@ -233,7 +233,7 @@ VideoControlScreen::VideoControlScreen(OptionsScreen::State* state)
             ->bind({
                     [] { return sys.prefs->fullscreen(); },
                     [](bool on) {
-                        sys.prefs->set_fullscreen(on);
+                        sys.video->set_fullscreen(on);
                     },
             });
 

--- a/src/video/text-driver.cpp
+++ b/src/video/text-driver.cpp
@@ -168,6 +168,10 @@ TextVideoDriver::TextVideoDriver(Size screen_size, const sfz::optional<pn::strin
 
 int TextVideoDriver::scale() const { return 1; }
 
+void TextVideoDriver::set_fullscreen(const bool on) {
+    log("fullscreen", on);
+}
+
 bool TextVideoDriver::start_editing(TextReceiver* text) { return false; }
 
 void TextVideoDriver::stop_editing(TextReceiver* text) {}


### PR DESCRIPTION
Clicking the "Fullscreen" checkbox in Options > Video now instantly toggles fullscreen mode.

In macOS, the green fullscreen button in the window titlebar has the same effect.

In Linux, alt-Enter continues to toggle fullscreen as before.

I tested this using both macOS Sonoma 14.2.1 and Asahi Fedora Remix on a 16" MBP M1 Max.