### PR TITLE
Write encoded UTF-8 explicitly in build-pix.cpp

### DIFF
--- a/src/bin/build-pix.cpp
+++ b/src/bin/build-pix.cpp
@@ -112,7 +112,7 @@ pn::string_view charset() {
            "Uu Úú Ùù Ûû Üü\n"
            "Yy Ÿÿ\n"
            "\n"
-           "\uf8ff\n";
+           "\xEF\xA3\xBF\n";
 }
 
 template <typename VideoDriver>


### PR DESCRIPTION
Required for #321. Windows won’t necessarily assume that a \u escape code is UTF-8.